### PR TITLE
Fixed issue #2

### DIFF
--- a/lib/findup-sync.js
+++ b/lib/findup-sync.js
@@ -23,7 +23,7 @@ module.exports = function(patterns, options) {
   // original object.
   var globOptions = Object.create(options || {});
   globOptions.maxDepth = 1;
-  globOptions.cwd = path.resolve(globOptions.cwd);
+  globOptions.cwd = path.resolve(globOptions.cwd || '');
 
   var files, lastpath;
   do {


### PR DESCRIPTION
path.resolve does not allow first argument to be anything other than string if it present.

``` javascript
globOptions.cwd = globOptions.cwd ?  path.resolve(globOptions.cwd) : path.resolve();
```

would also work
