### PR TITLE
normalized paths to make tests work cross platform

### DIFF
--- a/test/findup-sync_test.js
+++ b/test/findup-sync_test.js
@@ -22,23 +22,23 @@ exports['findup'] = {
   'simple': function(test) {
     test.expect(8);
     var opts = {cwd: 'test/fixtures/a/b'};
-    test.equal(rel(findup('foo.txt', opts)), 'test/fixtures/a/foo.txt', 'should find files');
-    test.equal(rel(findup('bar.txt', opts)), 'test/fixtures/a/b/bar.txt', 'should find files');
-    test.equal(rel(findup('a.txt', opts)), 'test/fixtures/a.txt', 'should find files');
-    test.equal(rel(findup('?.txt', opts)), 'test/fixtures/a.txt', 'should support glob patterns');
-    test.equal(rel(findup('*.txt', opts)), 'test/fixtures/a/b/bar.txt', 'should find the first thing that matches the glob pattern');
-    test.equal(rel(findup(['b*.txt', 'f*.txt'], opts)), 'test/fixtures/a/b/bar.txt', 'should find the first thing that matches any of the glob patterns');
-    test.equal(rel(findup(['f*.txt', 'b*.txt'], opts)), 'test/fixtures/a/b/bar.txt', 'should find the first thing that matches any of the glob patterns');
+    test.equal(rel(findup('foo.txt', opts)), path.normalize('test/fixtures/a/foo.txt'), 'should find files');
+    test.equal(rel(findup('bar.txt', opts)), path.normalize('test/fixtures/a/b/bar.txt'), 'should find files');
+    test.equal(rel(findup('a.txt', opts)), path.normalize('test/fixtures/a.txt'), 'should find files');
+    test.equal(rel(findup('?.txt', opts)), path.normalize('test/fixtures/a.txt'), 'should support glob patterns');
+    test.equal(rel(findup('*.txt', opts)), path.normalize('test/fixtures/a/b/bar.txt'), 'should find the first thing that matches the glob pattern');
+    test.equal(rel(findup(['b*.txt', 'f*.txt'], opts)), path.normalize('test/fixtures/a/b/bar.txt'), 'should find the first thing that matches any of the glob patterns');
+    test.equal(rel(findup(['f*.txt', 'b*.txt'], opts)), path.normalize('test/fixtures/a/b/bar.txt'), 'should find the first thing that matches any of the glob patterns');
     test.equal(findup('not-gonna-exist-i-hope.txt', opts), null, 'should returning null if no files found');
     test.done();
   },
   'cwd': function(test) {
     test.expect(8);
     process.chdir('test/fixtures/a/b');
-    test.equal(rel(findup('foo.txt')), '../foo.txt', 'should find files');
+    test.equal(rel(findup('foo.txt')), path.normalize('../foo.txt'), 'should find files');
     test.equal(rel(findup('bar.txt')), 'bar.txt', 'should find files');
-    test.equal(rel(findup('a.txt')), '../../a.txt', 'should find files');
-    test.equal(rel(findup('?.txt')), '../../a.txt', 'should support glob patterns');
+    test.equal(rel(findup('a.txt')), path.normalize('../../a.txt'), 'should find files');
+    test.equal(rel(findup('?.txt')), path.normalize('../../a.txt'), 'should support glob patterns');
     test.equal(rel(findup('*.txt')), 'bar.txt', 'should find the first thing that matches the glob pattern');
     test.equal(rel(findup(['b*.txt', 'f*.txt'])), 'bar.txt', 'should find the first thing that matches any of the glob patterns');
     test.equal(rel(findup(['f*.txt', 'b*.txt'])), 'bar.txt', 'should find the first thing that matches any of the glob patterns');


### PR DESCRIPTION
Here is the test changes for making tests run cross platform. Used path.normalize instead of path.join as it reads better. Tested on windows with node 0.8.15. 10 of 16 assertions failed before, now all pass.
