### PR TITLE
Use modularized Lo-Dash functions

### DIFF
--- a/lib/findup-sync.js
+++ b/lib/findup-sync.js
@@ -13,7 +13,9 @@ var path = require('path');
 
 // External libs.
 var glob = require('glob');
-var _ = require('lodash');
+var flatten = require('lodash.flatten');
+var map = require('lodash.map');
+var uniq = require('lodash.uniq');
 
 // Search for a filename in the given directory or all parent directories.
 module.exports = function(patterns, options) {
@@ -28,9 +30,12 @@ module.exports = function(patterns, options) {
   var files, lastpath;
   do {
     // Search for files matching patterns.
-    files = _(patterns).map(function(pattern) {
+    files = map(patterns, function(pattern) {
       return glob.sync(pattern, globOptions);
-    }).flatten().uniq().value();
+    });
+    files = flatten(files);
+    files = uniq(files);
+
     // Return file if found.
     if (files.length > 0) {
       return path.resolve(path.join(globOptions.cwd, files[0]));

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
   },
   "dependencies": {
     "glob": "~3.1.21",
-    "lodash": "~1.0.1"
+    "lodash.flatten": "~2.2.1",
+    "lodash.map": "~2.2.1",
+    "lodash.uniq": "~2.2.1"
   },
   "devDependencies": {
     "grunt": "~0.4.0",


### PR DESCRIPTION
Hey!

This PR updates Lo-Dash to ~2.2 and substitutes the `lodash` module for the modularized Lo-Dash functions introduced in Lo-Dash v2 (specifically, for this module: `lodash.map`, `lodash.flatten`, and `lodash.uniq`).

Unfortunately I had to get rid of the chaining you were using (that part of Lo-Dash isn't modularized), but I believe it is a worthwhile sacrifice for the disk space we save in dependencies :)
