### PR TITLE
Update glob dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "grunt nodeunit"
   },
   "dependencies": {
-    "glob": "~4.3.0"
+    "glob": "^5.0.10"
   },
   "devDependencies": {
     "grunt": "~0.4.4",


### PR DESCRIPTION
The newer version of `glob` supports `follow: true` (follow symlinked directories when expanding ** patterns).

This is needed for https://github.com/ember-cli/ember-cli/issues/4137.